### PR TITLE
Fixed the failure of the actions workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,7 @@
 name: Node.js Package
 
 on:
-  workflo_dispatch:
+  workflow_dispatch:
   release:
     types: [created]
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,7 @@
 name: Node.js Package
 
 on:
+  workflo_dispatch:
   release:
     types: [created]
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.2",
   "description": "a react component library for creating pretty, dynamic leaderboards",
   "scripts": {
-    "rollup": "rollup -c"
+    "rollup": "rollup -c",
+    "test": "jest"
   },
   "author": "dylan",
   "license": "ISC",
@@ -26,13 +27,11 @@
     "@tremor/react": "^2.4.0",
     "tailwindcss": "^3.3.2"
   },
-
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],
-
   "types": "dist/index.d.ts",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",


### PR DESCRIPTION
- Fixes #1 

- The workflow was trying to run `npm test` but there was no `test` script present in the `package.json`. The solution is to add the `test` script in `package.json`.
- Having a manual trigger option can be beneficial in some cases, which I have added here